### PR TITLE
Base url has been reactored to the cypress.json

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,5 @@
 {
-  "pluginsFile": "tests/e2e/plugins/index.js"
+  "baseUrl": "http://localhost:8081",
+  "pluginsFile": "tests/e2e/plugins/index.js",
+  "projectId": "qawufu"
 }


### PR DESCRIPTION
This PR provides:

+ base url for cypress e2e tests