### PR TITLE
59 refactor magazines tests to use mocked api routes

### DIFF
--- a/demo/App.vue
+++ b/demo/App.vue
@@ -7,9 +7,8 @@
         :create='fieldsArticleCreate'
         :edit='fieldsArticleEdit'
         :resourceIdName='resourceIdName'
-        :apiUrl='apiUrl'
-        >
-      </Resource>
+        :apiUrl='articlesApiUrl'
+      />
       <Resource
         name='magazines'
         :list='ListMagazines'
@@ -17,9 +16,8 @@
         :create='CreateMagazines'
         :edit='EditMagazines'
         :resourceIdName='resourceIdName'
-        :apiUrl='apiUrl'
-        >
-      </Resource>
+        :apiUrl='magazinesApiUrl'
+      />
     </Admin>
 </template>
 
@@ -116,7 +114,8 @@ const fieldsMagazineEdit = fieldsMagazineCreate
 //   }
 // }
 
-const apiUrl = 'http://localhost:8080/api/'
+const articlesApiUrl = 'http://localhost:8080/api/'
+const magazinesApiUrl = 'http://localhost:8888/api/'
 
 export default {
   name: "App",
@@ -126,7 +125,8 @@ export default {
   },
   data() {
     return {
-      apiUrl,
+      articlesApiUrl,
+      magazinesApiUrl,
       articlesList,
       articlesShow,
       fieldsArticleCreate,

--- a/demo/components/ListMagazines.vue
+++ b/demo/components/ListMagazines.vue
@@ -59,6 +59,10 @@
       :headers="headers"
       :items="desserts"
       class="elevation-1"
+      disable-initial-sort
+      :pagination.sync="pagination"
+      :dark="true"
+      rows-per-page-text="Magazines per page"
     >
       <template slot="no-data">
         <v-alert :value="true" color="warning" icon="warning">
@@ -68,7 +72,8 @@
 
       <template slot="items" slot-scope="props">
         <td :name="idRowName(props.index)">{{ props.item.id }}</td>
-        <td :name="issueRowName(props.index)" class="text-xs-right">{{ props.item.issue }}</td>
+        <td :name="nameRowName(props.index)" class="text-xs-left">{{ props.item.name }}</td>
+        <td :name="issueRowName(props.index)" class="text-xs-center">{{ props.item.issue }}</td>
         <td :name="publisherRowName(props.index)" class="text-xs-right">{{ props.item.publisher }}</td>
       </template>
 
@@ -78,6 +83,7 @@
 
 <script>
   import UI_NAMES from '@constants/ui.element.names'
+  import { rowsPerPage } from '../constants'
 
   export default {
     name: 'ListMagazines',
@@ -101,14 +107,20 @@
       })
       return {
         idRowName: (index) => buildName('id', index),
+        nameRowName: (index) => buildName('name', index),
         issueRowName: (index) => buildName('issue', index),
-        publisherRowName: (index) => buildName('publisher', index)
+        publisherRowName: (index) => buildName('publisher', index),
+        pagination: {
+          page: 1,
+          rowsPerPage
+        }
       }
     },
     computed: {
       headers: function() {
         return [
           { text: 'ID', align: 'left', sortable: true, value: 'id' },
+          { text: 'Name', value: 'name' },
           { text: 'Issue', value: 'issue' },
           { text: 'Publisher', value: 'publisher' }
         ]

--- a/demo/constants/index.js
+++ b/demo/constants/index.js
@@ -1,0 +1,2 @@
+
+export const rowsPerPage = 14

--- a/tests/e2e/factory/store/initial.getters.js
+++ b/tests/e2e/factory/store/initial.getters.js
@@ -1,8 +1,7 @@
 import { initialResourcesRoutes } from './common.utils'
 
-
 /**
- * Annonymous Function - Creates a simualtion of initial vuex crud getters
+ * Anonymous Function - Creates a simualtion of initial vuex crud getters
  *
  * @return {Object} The expected Vuex Crud mocked getters
  */

--- a/tests/e2e/factory/store/initial.state.js
+++ b/tests/e2e/factory/store/initial.state.js
@@ -1,7 +1,7 @@
 import { initialResourcesRoutes } from './common.utils'
 
 /**
- * Annonymous Function - Creates a simualtion of initial vuex crud state
+ * Anonymous Function - Creates a simualtion of initial vuex crud state
  *
  * @return {Object} The expected Vuex Crud mocked state
  */

--- a/tests/e2e/fixtures/magazines.json
+++ b/tests/e2e/fixtures/magazines.json
@@ -1,0 +1,722 @@
+[
+  {
+    "id": 158217,
+    "name": "Oamoi noch dadst Au Bladl.",
+    "issue": "#1184",
+    "publisher": "Vue Admin aspera iaspis Deandlgwand fensdaln mogsd."
+  },
+  {
+    "id": 47576,
+    "name": "Aa Leonhardifahrt God God.",
+    "issue": "#573",
+    "publisher": "Vue Admin aspera iaspis Nia Buachbinda moand Spotzerl biazelt bissal."
+  },
+  {
+    "id": 56913,
+    "name": "Vergeltsgott dadst gmahde trihöleridi Hoiwe, schnacksln.",
+    "issue": "#985",
+    "publisher": "Vue Admin aspera iaspis Kost moan Marei."
+  },
+  {
+    "id": 4172,
+    "name": "Samma, red Bavariae Wurschtsolod Luja sammawiedaguad.",
+    "issue": "#1552",
+    "publisher": "Vue Admin aspera iaspis Gar, an wo Radi Biawambn."
+  },
+  {
+    "id": 208644,
+    "name": "Wo Spuiratz Koa wiad Bussal Prosd.",
+    "issue": "#1825",
+    "publisher": "Vue Admin aspera iaspis Suri I, um gscheit."
+  },
+  {
+    "id": 151826,
+    "name": "Semmlkneedl bussal heid von fensdaln.",
+    "issue": "#591",
+    "publisher": "Vue Admin aspera iaspis Uns Sodala Greaßt maibam bin."
+  },
+  {
+    "id": 34383,
+    "name": "Sauakraud Berg.",
+    "issue": "#234",
+    "publisher": "Vue Admin aspera iaspis Watschnpladdla midanand ma."
+  },
+  {
+    "id": 194927,
+    "name": "Oamoi baddscher, af Buachbinda.",
+    "issue": "#890",
+    "publisher": "Vue Admin aspera iaspis Obacht ollaweil mim."
+  },
+  {
+    "id": 130914,
+    "name": "Foidweg, Au sagrisch, Steckerleis.",
+    "issue": "#305",
+    "publisher": "Vue Admin aspera iaspis Nia enzian leck."
+  },
+  {
+    "id": 196872,
+    "name": "Gwihss Ledahosn Bussal Schellnsau gehd, g'hupft.",
+    "issue": "#444",
+    "publisher": "Vue Admin aspera iaspis Hetschapfah Engelgwand Sog."
+  },
+  {
+    "id": 97308,
+    "name": "Weibaleid sodala, weibaleid enzian.",
+    "issue": "#1754",
+    "publisher": "Vue Admin aspera iaspis Oans Wurschtsolod resch."
+  },
+  {
+    "id": 231202,
+    "name": "Sagrisch bin amoi.",
+    "issue": "#1593",
+    "publisher": "Vue Admin aspera iaspis Aso gehd etza es Mordsgaudi Gott."
+  },
+  {
+    "id": 50118,
+    "name": "Ma scheans nimma Prosit.",
+    "issue": "#984",
+    "publisher": "Vue Admin aspera iaspis Spernzaln ebba bravs marterl need."
+  },
+  {
+    "id": 207605,
+    "name": "Nachad Ohrwaschl Heiwog wiad Hoiwe.",
+    "issue": "#1318",
+    "publisher": "Vue Admin aspera iaspis Hetschapfah Nix gwiss goaßmaß, baddscher ma."
+  },
+  {
+    "id": 84988,
+    "name": "Radler scheans Radi.",
+    "issue": "#708",
+    "publisher": "Vue Admin aspera iaspis Bloß singd pfundig gscheid."
+  },
+  {
+    "id": 221022,
+    "name": "Middn fui Stubn wui.",
+    "issue": "#1797",
+    "publisher": "Vue Admin aspera iaspis Giasinga kloan kimmt Gmiadlichkeit Hoam Sauwedda."
+  },
+  {
+    "id": 58269,
+    "name": "Umma dringma Brotzeit Schorsch resch, Schneid.",
+    "issue": "#1154",
+    "publisher": "Vue Admin aspera iaspis Ewig kost Deandl schorsch im."
+  },
+  {
+    "id": 207459,
+    "name": "Leck nieda.",
+    "issue": "#13",
+    "publisher": "Vue Admin aspera iaspis Woschechta ded Gschicht singd griasd."
+  },
+  {
+    "id": 1967,
+    "name": "Middn obandeln noch.",
+    "issue": "#542",
+    "publisher": "Vue Admin aspera iaspis Fensdaln Spuiratz ognudelt scho."
+  },
+  {
+    "id": 67866,
+    "name": "Sagrisch radi sepp wann woass, gehds.",
+    "issue": "#149",
+    "publisher": "Vue Admin aspera iaspis Measi wirds, Ohrwaschl om."
+  },
+  {
+    "id": 73860,
+    "name": "Sodala gscheit so Gelbe.",
+    "issue": "#536",
+    "publisher": "Vue Admin aspera iaspis Resch ded bitt es Watschnbaam Servas."
+  },
+  {
+    "id": 105210,
+    "name": "Nia nix a maibam Gamsbart kimmt.",
+    "issue": "#1923",
+    "publisher": "Vue Admin aspera iaspis Obandln Dog nimmds Lem kummd sammawiedaguad."
+  },
+  {
+    "id": 39118,
+    "name": "Almrausch kloan Schuabladdla.",
+    "issue": "#833",
+    "publisher": "Vue Admin aspera iaspis Lem oa."
+  },
+  {
+    "id": 211319,
+    "name": "Ewig gfoids mechad.",
+    "issue": "#865",
+    "publisher": "Vue Admin aspera iaspis Schellnsau Schaung nachad."
+  },
+  {
+    "id": 89976,
+    "name": "Basd kummd acht'n gar Diandldrahn.",
+    "issue": "#1303",
+    "publisher": "Vue Admin aspera iaspis Nois nois, Woibbadinga hawadere schoo."
+  },
+  {
+    "id": 42670,
+    "name": "Brodzeid middn scheans Goaßmaß Gwiass.",
+    "issue": "#497",
+    "publisher": "Vue Admin aspera iaspis Amoi Singan Mamalad radler fescha, Sünd."
+  },
+  {
+    "id": 32021,
+    "name": "Greaßt Schnacksln jedza So jedza.",
+    "issue": "#1357",
+    "publisher": "Vue Admin aspera iaspis Bua An Greichats middn am, Maibam."
+  },
+  {
+    "id": 181262,
+    "name": "Schdeckalfisch hea kloan.",
+    "issue": "#285",
+    "publisher": "Vue Admin aspera iaspis Bayer Gmiadlichkeit Fensdaln Oachkatzlschwoaf."
+  },
+  {
+    "id": 227326,
+    "name": "Gwihss God bitt Schnacksln middn moand.",
+    "issue": "#972",
+    "publisher": "Vue Admin aspera iaspis Weibaleid ebba, bussal, radler."
+  },
+  {
+    "id": 101010,
+    "name": "Nachad freibia.",
+    "issue": "#1138",
+    "publisher": "Vue Admin aspera iaspis Wolpern brotzeit om Hendl ebba Servas."
+  },
+  {
+    "id": 176378,
+    "name": "Gfreit, maßkruag.",
+    "issue": "#1471",
+    "publisher": "Vue Admin aspera iaspis So unbandig aba Biaschlegl."
+  },
+  {
+    "id": 209866,
+    "name": "Auffisteign nimmds.",
+    "issue": "#1514",
+    "publisher": "Vue Admin aspera iaspis Nomoi, Kini oba Do."
+  },
+  {
+    "id": 5455,
+    "name": "Drei weibaleid mog marei g'hupft.",
+    "issue": "#217",
+    "publisher": "Vue Admin aspera iaspis Resi haferl gor."
+  },
+  {
+    "id": 65904,
+    "name": "Griasd ebba, Heiwog.",
+    "issue": "#1079",
+    "publisher": "Vue Admin aspera iaspis Gscheit Spotzerl, Edlweiss von I."
+  },
+  {
+    "id": 63249,
+    "name": "Legst Mim Prosd Mim.",
+    "issue": "#1125",
+    "publisher": "Vue Admin aspera iaspis Gsuffa bitt Sünd, eana woar Aasgem."
+  },
+  {
+    "id": 216490,
+    "name": "Maßkruag sepp.",
+    "issue": "#1963",
+    "publisher": "Vue Admin aspera iaspis Lewakaas heitzdog nia."
+  },
+  {
+    "id": 125567,
+    "name": "Schmarn oamoi, red Weißwiaschd Schaung beinand.",
+    "issue": "#318",
+    "publisher": "Vue Admin aspera iaspis Sepp gehd Haberertanz Heimatland, oba."
+  },
+  {
+    "id": 95154,
+    "name": "Im uns Broadwurschtbudn Im hogg.",
+    "issue": "#211",
+    "publisher": "Vue Admin aspera iaspis Hi daugn Schellnsau."
+  },
+  {
+    "id": 4938,
+    "name": "Deandlgwand Fünferl.",
+    "issue": "#1631",
+    "publisher": "Vue Admin aspera iaspis Bitt, fensdaln."
+  },
+  {
+    "id": 139507,
+    "name": "Brodzeid Weibaleid wuid.",
+    "issue": "#96",
+    "publisher": "Vue Admin aspera iaspis Brotzeit Mordsgaudi eana Edlweiss."
+  },
+  {
+    "id": 103193,
+    "name": "Gscheckate dahoam greana Prosit.",
+    "issue": "#1658",
+    "publisher": "Vue Admin aspera iaspis Sammawiedaguad, samma Schdarmbeaga in."
+  },
+  {
+    "id": 31134,
+    "name": "Singd Blosmusi Fünferl lossn nomoi.",
+    "issue": "#1995",
+    "publisher": "Vue Admin aspera iaspis Maßkruag kumm."
+  },
+  {
+    "id": 172873,
+    "name": "Lewakaas muass gehds Schmarn.",
+    "issue": "#188",
+    "publisher": "Vue Admin aspera iaspis Schaung auffi gschicht wiavui, gscheckate."
+  },
+  {
+    "id": 75126,
+    "name": "Midananda in.",
+    "issue": "#1944",
+    "publisher": "Vue Admin aspera iaspis Moan Trachtnhuat heitzdog Umma."
+  },
+  {
+    "id": 241562,
+    "name": "Wurscht beim.",
+    "issue": "#1049",
+    "publisher": "Vue Admin aspera iaspis Foidweg Haferl hog dea anbandeln anbandeln."
+  },
+  {
+    "id": 93626,
+    "name": "Mas nois an wurschtsolod wuid umananda.",
+    "issue": "#153",
+    "publisher": "Vue Admin aspera iaspis Heimatland need."
+  },
+  {
+    "id": 186880,
+    "name": "Wann Watschnpladdla gwihss deandlgwand, wui.",
+    "issue": "#1576",
+    "publisher": "Vue Admin aspera iaspis Spezi Umma vo."
+  },
+  {
+    "id": 219609,
+    "name": "Wuascht samma Biagadn Schwoanshaxn Sodala.",
+    "issue": "#833",
+    "publisher": "Vue Admin aspera iaspis Daugn brotzeit i, anbandeln Mehra Back."
+  },
+  {
+    "id": 171271,
+    "name": "Trihöleridi kenna singan Schellnsau.",
+    "issue": "#1221",
+    "publisher": "Vue Admin aspera iaspis Wolpern Biawambn Wea, auf'd Obazda soi."
+  },
+  {
+    "id": 10091,
+    "name": "Oiwei hea Semmlkneedl auf'n gscheid.",
+    "issue": "#246",
+    "publisher": "Vue Admin aspera iaspis Klampfn kummd wolpern leck Leit."
+  },
+  {
+    "id": 239367,
+    "name": "Nimma jedza Klampfn im.",
+    "issue": "#436",
+    "publisher": "Vue Admin aspera iaspis Eana Hemad."
+  },
+  {
+    "id": 245176,
+    "name": "Haferl mog schorsch koa.",
+    "issue": "#295",
+    "publisher": "Vue Admin aspera iaspis Schnacksln Spezi Luja."
+  },
+  {
+    "id": 34676,
+    "name": "A Buachbinda, sei Watschnbaam.",
+    "issue": "#354",
+    "publisher": "Vue Admin aspera iaspis Huift Bradwurschtsemmal Heiwog."
+  },
+  {
+    "id": 20425,
+    "name": "Wuascht, Damischa griasd.",
+    "issue": "#1228",
+    "publisher": "Vue Admin aspera iaspis Da Schdarmbeaga sauba Greaßt schdarmbeaga."
+  },
+  {
+    "id": 224270,
+    "name": "Wea woschechta heitzdog hinter'm.",
+    "issue": "#906",
+    "publisher": "Vue Admin aspera iaspis Gamsbart Bradwurschtsemmal blärrd o'ha marei soi."
+  },
+  {
+    "id": 199898,
+    "name": "Daad, Weiznglasl.",
+    "issue": "#1733",
+    "publisher": "Vue Admin aspera iaspis Resch heitzdog g'hupft Greaßt biazelt huift."
+  },
+  {
+    "id": 169307,
+    "name": "Maderln woass.",
+    "issue": "#782",
+    "publisher": "Vue Admin aspera iaspis Zünftig muass aa Nimma Diandldrahn."
+  },
+  {
+    "id": 103461,
+    "name": "Vasteh Schellnsau So Damischa.",
+    "issue": "#318",
+    "publisher": "Vue Admin aspera iaspis In nomoi gamsbart pfenningguat."
+  },
+  {
+    "id": 178740,
+    "name": "Greana Rüam.",
+    "issue": "#1332",
+    "publisher": "Vue Admin aspera iaspis Gfreit Prosit."
+  },
+  {
+    "id": 214543,
+    "name": "Von Damischa griaß.",
+    "issue": "#1961",
+    "publisher": "Vue Admin aspera iaspis Sünd, auf'd Edlweiss, muas basd."
+  },
+  {
+    "id": 62339,
+    "name": "Von Prosit und, nackata.",
+    "issue": "#1312",
+    "publisher": "Vue Admin aspera iaspis Gscheckate Obandln kenna."
+  },
+  {
+    "id": 247130,
+    "name": "Meidromml Buachbinda.",
+    "issue": "#608",
+    "publisher": "Vue Admin aspera iaspis Af no."
+  },
+  {
+    "id": 200639,
+    "name": "Obacht Schdarmbeaga Schuabladdla om griasd oamoi.",
+    "issue": "#1885",
+    "publisher": "Vue Admin aspera iaspis Brotzeit Heimatland Bayer Brodzeid."
+  },
+  {
+    "id": 220478,
+    "name": "Hob Habedehre im bravs Deandl.",
+    "issue": "#168",
+    "publisher": "Vue Admin aspera iaspis Hemad weibaleid."
+  },
+  {
+    "id": 16737,
+    "name": "Ozapfa vasteh Ramasuri.",
+    "issue": "#98",
+    "publisher": "Vue Admin aspera iaspis Buachbinda schdarmbeaga Auf Woibbadinga lem Hetschapfah."
+  },
+  {
+    "id": 185185,
+    "name": "Ollaweil schaugn.",
+    "issue": "#978",
+    "publisher": "Vue Admin aspera iaspis Wann daugn kenna."
+  },
+  {
+    "id": 7222,
+    "name": "Leonhardifahrt Back.",
+    "issue": "#1858",
+    "publisher": "Vue Admin aspera iaspis Kuaschwanz Gamsbart God kummd vo wujn."
+  },
+  {
+    "id": 95353,
+    "name": "Gehds Godds Schuabladdla fei kummd legst.",
+    "issue": "#200",
+    "publisher": "Vue Admin aspera iaspis Umma nimmds Reiwadatschi oiwei, Bitt."
+  },
+  {
+    "id": 114902,
+    "name": "Gelbe g'hupft.",
+    "issue": "#894",
+    "publisher": "Vue Admin aspera iaspis Meidromml Berg daad Broadwurschtbudn jedza g'hupft."
+  },
+  {
+    "id": 122769,
+    "name": "Resi fei Kirwa.",
+    "issue": "#1127",
+    "publisher": "Vue Admin aspera iaspis Gean Weißwiaschd geh di."
+  },
+  {
+    "id": 13862,
+    "name": "Uns, schuabladdla.",
+    "issue": "#415",
+    "publisher": "Vue Admin aspera iaspis Fui Wurscht is Gar."
+  },
+  {
+    "id": 249457,
+    "name": "Sünd Wanninger.",
+    "issue": "#418",
+    "publisher": "Vue Admin aspera iaspis Etza, Im."
+  },
+  {
+    "id": 34778,
+    "name": "Spotzerl narrisch Di Schaung.",
+    "issue": "#1365",
+    "publisher": "Vue Admin aspera iaspis Des Biawambn schuabladdla."
+  },
+  {
+    "id": 53195,
+    "name": "Eich measi.",
+    "issue": "#1972",
+    "publisher": "Vue Admin aspera iaspis Legst Schbozal wolln deandlgwand owe."
+  },
+  {
+    "id": 86557,
+    "name": "Boarischer oiwei an.",
+    "issue": "#198",
+    "publisher": "Vue Admin aspera iaspis Muass nia."
+  },
+  {
+    "id": 173254,
+    "name": "Gscheit bitt hera kummt Kini, Back.",
+    "issue": "#193",
+    "publisher": "Vue Admin aspera iaspis Luja nia Griasd."
+  },
+  {
+    "id": 16225,
+    "name": "Eam amoi Schbozal.",
+    "issue": "#1640",
+    "publisher": "Vue Admin aspera iaspis Red hawadere a Stubn Gott."
+  },
+  {
+    "id": 48463,
+    "name": "Fescha landla dadst Schdeckalfisch lossn.",
+    "issue": "#654",
+    "publisher": "Vue Admin aspera iaspis Fias oiwei bissal."
+  },
+  {
+    "id": 42727,
+    "name": "Wanninger Blosmusi.",
+    "issue": "#507",
+    "publisher": "Vue Admin aspera iaspis Hemad, woschechta Gipfe gar der."
+  },
+  {
+    "id": 229404,
+    "name": "Kloan, Mamalad gar So.",
+    "issue": "#1918",
+    "publisher": "Vue Admin aspera iaspis Schaugn, denn."
+  },
+  {
+    "id": 114239,
+    "name": "Mi soi Graudwiggal.",
+    "issue": "#1335",
+    "publisher": "Vue Admin aspera iaspis Bladl mim schüds."
+  },
+  {
+    "id": 165183,
+    "name": "Dea schaugn wurschtsolod Wea.",
+    "issue": "#1009",
+    "publisher": "Vue Admin aspera iaspis Bussal Meidromml."
+  },
+  {
+    "id": 144141,
+    "name": "Ma Wiesn Bia Ramasuri.",
+    "issue": "#1149",
+    "publisher": "Vue Admin aspera iaspis Oa ganze Abfieseln."
+  },
+  {
+    "id": 215393,
+    "name": "Aasgem, fui Aasgem.",
+    "issue": "#1336",
+    "publisher": "Vue Admin aspera iaspis Prosit spezi spernzaln, hemad."
+  },
+  {
+    "id": 221148,
+    "name": "Scho, hea wolln gar.",
+    "issue": "#1395",
+    "publisher": "Vue Admin aspera iaspis Damischa, wirds moand amoi der Fingahaggln."
+  },
+  {
+    "id": 171656,
+    "name": "Biawambn eich ollaweil Jodler mehra.",
+    "issue": "#619",
+    "publisher": "Vue Admin aspera iaspis Mehra Tag."
+  },
+  {
+    "id": 15303,
+    "name": "Resi ognudelt baamwach jedza See Zidern.",
+    "issue": "#1445",
+    "publisher": "Vue Admin aspera iaspis Sauba baamwach Charivari ma."
+  },
+  {
+    "id": 184654,
+    "name": "Kumm, Namidog, An.",
+    "issue": "#702",
+    "publisher": "Vue Admin aspera iaspis Sammawiedaguad hallelujah trihöleridi."
+  },
+  {
+    "id": 86267,
+    "name": "Nimmds zua iabaroi gamsbart.",
+    "issue": "#248",
+    "publisher": "Vue Admin aspera iaspis Midananda Fensdaln Ohrwaschl Back."
+  },
+  {
+    "id": 127879,
+    "name": "Prosd o'ha, Schuabladdla Sog Namidog.",
+    "issue": "#1052",
+    "publisher": "Vue Admin aspera iaspis Fescha Meidromml bitt Auffisteign is."
+  },
+  {
+    "id": 91621,
+    "name": "Samma, ko Godds im da.",
+    "issue": "#168",
+    "publisher": "Vue Admin aspera iaspis Gams du bravs weibaleid."
+  },
+  {
+    "id": 42689,
+    "name": "Almrausch lem.",
+    "issue": "#1236",
+    "publisher": "Vue Admin aspera iaspis Midnand hob."
+  },
+  {
+    "id": 91483,
+    "name": "Mas Gaudi.",
+    "issue": "#622",
+    "publisher": "Vue Admin aspera iaspis Glacht ozapfa nacha."
+  },
+  {
+    "id": 192651,
+    "name": "Gelbe kuaschwanz, marterl.",
+    "issue": "#1740",
+    "publisher": "Vue Admin aspera iaspis Kloan, Schaung In hemad Gstanzl wiad."
+  },
+  {
+    "id": 85599,
+    "name": "Mim aso greaßt.",
+    "issue": "#1588",
+    "publisher": "Vue Admin aspera iaspis Auf'n Kaiwe schorsch freibia Buachbinda."
+  },
+  {
+    "id": 160469,
+    "name": "Schorsch iabaroi sodala mi kloan freibia.",
+    "issue": "#998",
+    "publisher": "Vue Admin aspera iaspis Damischa Nix schuabladdla oa, Gott heitzdog."
+  },
+  {
+    "id": 119989,
+    "name": "Greaßt geh Breihaus, liab.",
+    "issue": "#360",
+    "publisher": "Vue Admin aspera iaspis Gmahde mas z'dringa Beidl bitt Watschnbaam."
+  },
+  {
+    "id": 142489,
+    "name": "Wujn dringma is.",
+    "issue": "#785",
+    "publisher": "Vue Admin aspera iaspis Nix auszutzeln pfiad Bayer Dog liberalitas."
+  },
+  {
+    "id": 113759,
+    "name": "Midananda kloan.",
+    "issue": "#395",
+    "publisher": "Vue Admin aspera iaspis Oiwei obandeln beinand gscheit."
+  },
+  {
+    "id": 56104,
+    "name": "Radi abfieseln sog Musi.",
+    "issue": "#1230",
+    "publisher": "Vue Admin aspera iaspis Wolpern sauwedda."
+  },
+  {
+    "id": 70365,
+    "name": "Fescha, kost Gidarn gscheit.",
+    "issue": "#1672",
+    "publisher": "Vue Admin aspera iaspis Klampfn greaßt."
+  },
+  {
+    "id": 81080,
+    "name": "Gscheit mogsd.",
+    "issue": "#283",
+    "publisher": "Vue Admin aspera iaspis Namidog Sei spezi middn hoam."
+  },
+  {
+    "id": 241529,
+    "name": "Charivari, wurschtsolod legst Gschicht Haberertanz So.",
+    "issue": "#1481",
+    "publisher": "Vue Admin aspera iaspis Kaiwe Mordsgaudi mas, amoi."
+  },
+  {
+    "id": 210739,
+    "name": "Gscheckate gehd, und.",
+    "issue": "#1411",
+    "publisher": "Vue Admin aspera iaspis Ewig mas haferl narrisch greana."
+  },
+  {
+    "id": 90303,
+    "name": "Koa nacha.",
+    "issue": "#1069",
+    "publisher": "Vue Admin aspera iaspis Leonhardifahrt schee Sepp Sodala schüds Bladl."
+  },
+  {
+    "id": 237737,
+    "name": "Muas wolln Marei Schdarmbeaga.",
+    "issue": "#1290",
+    "publisher": "Vue Admin aspera iaspis Da Prosd Reiwadatschi."
+  },
+  {
+    "id": 175226,
+    "name": "Wea Freibia, midananda bissal.",
+    "issue": "#923",
+    "publisher": "Vue Admin aspera iaspis Klampfn Edlweiss."
+  },
+  {
+    "id": 57574,
+    "name": "Ausgähd legst.",
+    "issue": "#1380",
+    "publisher": "Vue Admin aspera iaspis Koa Godds."
+  },
+  {
+    "id": 35335,
+    "name": "Gamsbart, Hetschapfah gar haferl.",
+    "issue": "#469",
+    "publisher": "Vue Admin aspera iaspis Goaßmaß Schorsch I dijidiholleri gfoids."
+  },
+  {
+    "id": 24437,
+    "name": "Hetschapfah Deandl woaß.",
+    "issue": "#1638",
+    "publisher": "Vue Admin aspera iaspis Edlweiss ja schuabladdla unbandig aba."
+  },
+  {
+    "id": 49733,
+    "name": "Red Samma do Heimatland im middn.",
+    "issue": "#1058",
+    "publisher": "Vue Admin aspera iaspis Owe, Schellnsau foahn, Brodzeid."
+  },
+  {
+    "id": 123800,
+    "name": "Brotzeit griasd.",
+    "issue": "#48",
+    "publisher": "Vue Admin aspera iaspis Pfundig Edlweiss ledahosn bin Radl Mordsgaudi."
+  },
+  {
+    "id": 64160,
+    "name": "Maß Graudwiggal.",
+    "issue": "#1229",
+    "publisher": "Vue Admin aspera iaspis Edlweiss Wanninger Griasnoggalsubbm, hogg Bia sagrisch."
+  },
+  {
+    "id": 211036,
+    "name": "Charivari Au moan Brotzeit.",
+    "issue": "#499",
+    "publisher": "Vue Admin aspera iaspis Af es."
+  },
+  {
+    "id": 228203,
+    "name": "Greaßt des auf'n Weißwiaschd basd spotzerl.",
+    "issue": "#565",
+    "publisher": "Vue Admin aspera iaspis Heiwog goaßmaß."
+  },
+  {
+    "id": 59556,
+    "name": "Bin dadst Servas Schnacksln.",
+    "issue": "#1566",
+    "publisher": "Vue Admin aspera iaspis Gscheid hemad ledahosn om."
+  },
+  {
+    "id": 27933,
+    "name": "Sauwedda muass.",
+    "issue": "#353",
+    "publisher": "Vue Admin aspera iaspis Fensdaln woaß hetschapfah deandlgwand woaß, Mordsgaudi."
+  },
+  {
+    "id": 222038,
+    "name": "Radler, auf'n.",
+    "issue": "#350",
+    "publisher": "Vue Admin aspera iaspis An, ko, Wolpern Gipfe Mordsgaudi Blosmusi."
+  },
+  {
+    "id": 23849,
+    "name": "Heitzdog acht'n kloan Oim.",
+    "issue": "#284",
+    "publisher": "Vue Admin aspera iaspis Sowos wurschtsolod sammawiedaguad."
+  },
+  {
+    "id": 161487,
+    "name": "Hemad marei Leonhardifahrt Wiesn.",
+    "issue": "#1820",
+    "publisher": "Vue Admin aspera iaspis Kummt ko, vo."
+  }
+]

--- a/tests/e2e/lib/server.js
+++ b/tests/e2e/lib/server.js
@@ -20,9 +20,9 @@ export default ({
 
     // New endpoints should be added here
     const initEndpoints = {
-      list: (args) => listRequest(args),
-      create: (args) => createRequest(args),
-      edit: (args) => editRequest(args)
+      list: listRequest,
+      create: createRequest,
+      edit: editRequest
     }
 
     /**

--- a/tests/e2e/lib/server.js
+++ b/tests/e2e/lib/server.js
@@ -1,0 +1,78 @@
+import { numbers } from '../factory/utils'
+
+/**
+ * Anonymous Function - Given a resourceName and a view, initialises the
+ * Cypress server with a stubbed route.
+ *
+ * @param {String} resourceName The resource name used to build the request url
+ * @param {Array}  routes       An array of routes with name and an optional
+ *                              response to initialise stubbed endpoints
+ */
+export default ({
+  resourceName,
+  routes
+}) => {
+  // Initialises the Cypress server
+  cy.server()
+  // Gets the {resourceName} fixture
+  cy.fixture(resourceName).then(fixture => {
+    let data = fixture
+
+    // New endpoints should be added here
+    const initEndpoints = {
+      list: (args) => listRequest(args),
+      create: (args) => createRequest(args),
+      edit: (args) => editRequest(args)
+    }
+
+    /**
+     * listRequest - A stub for GET Many requests
+     */
+    function listRequest({ response }) {
+      cy.route({
+        method: 'GET',
+        url: `api/${resourceName}/`,
+        response: response || data
+      }).as(`${resourceName}/list`)
+    }
+
+    /**
+     * createRequest - A stub for POST requests
+     */
+    function createRequest({ response }) {
+      const entity = response
+      entity.id = numbers.randomBetween(1, 250000)
+      cy.route({
+        method: 'POST',
+        url: `**/api/${resourceName}/`,
+        status: 201,
+        onRequest: () => {
+          data.push(entity)
+        },
+        response: entity
+      }).as(`${resourceName}/create`)
+    }
+
+    /**
+     * editRequest - A stub for PATCH requests
+     */
+    function editRequest({ response }) {
+      cy.route(
+        'PATCH',
+        `**/api/${resourceName}/*`,
+        response,
+        {
+          onRequest: () => {
+            data = data.filter(element => response.id !== element.id)
+            data.push(response)
+          }
+        }
+      ).as(`${resourceName}/update`)
+    }
+
+    // Initialises endpoints
+    routes.forEach(route => {
+      initEndpoints[route.name](route)
+    })
+  })
+}

--- a/tests/e2e/specs/magazines/show.spec.js
+++ b/tests/e2e/specs/magazines/show.spec.js
@@ -1,5 +1,3 @@
-const Factory = require('../../factory')
-
 const { InitEntityUtils } = require('../../lib/commands')
 
 describe('Magazines: Show Action Test', () => {
@@ -11,20 +9,26 @@ describe('Magazines: Show Action Test', () => {
     view
   })
 
-  before('Creates a new magazine', () => {
-    const url = Factory.apiUrl({ route: `api/${resourceName}/` })
-    cy.request('POST', url, Factory.createMagazine()).
-    then((res) => { magazine = res.body })
+  before('Initialises the server', () => {
+    // Inits the server with a stubbed list to fetch all magazines
+    const routes = [ { name: 'list' } ]
+    cy.InitServer({ resourceName, routes })
   })
 
   before('Visits the magazines list', () => {
     // FIXME: Workaround until we fix the show path push when the store is empty
     cy.visit(`/#/${resourceName}/`)
-    cy.wait(2000)
+    cy.wait(`@${resourceName}/list`).then(xmlHttpRequest => {
+      // Takes the first element of the list to show
+      magazine = xmlHttpRequest.response.body[0]
+    })
+    cy.server({ enable: false })
   })
 
   it('Visits the magazines show url and the path should be magazines/show', () => {
+    // Exercise: visits the show view
     cy.visit(`/#/${resourceName}/${view}/${magazine.id}`)
+    // Assertion: the url should match the show view url
     cy.url().should('include', `${resourceName}/${view}`)
   })
 

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -3,10 +3,12 @@ import {
   getElement,
   getStore
 } from '../lib/commands'
+import InitServer from '../lib/server'
 
 Cypress.Commands.add('getStore', () => getStore())
 Cypress.Commands.add('InitEntityUtils', (args) => InitEntityUtils(args))
 Cypress.Commands.add('getElement', (args) => getElement(args))
+Cypress.Commands.add('InitServer', (args) => InitServer(args))
 
 // ***********************************************
 // This example commands.js shows you how to


### PR DESCRIPTION
This PR provides:

+ Magazines test re-implementation to use a stubbed API using Cypress
+ Testing utilities to stub routes
+ A magazines fixture

Closes: #59 