### PR TITLE
149 an authlayout component is not being passed to admin

### DIFF
--- a/Docs/Admin/Composer.md
+++ b/Docs/Admin/Composer.md
@@ -4,6 +4,12 @@ The `Composer` wrapper for the `Admin` is nothing more than a functional compone
 
 ## props
 
+### authLayout
+
++   **Type:** `Object (optional)`
+
++   **Details:** A component to log in that is passed as prop to `Admin`
+
 ### authProvider
 
 +   **Type:** `Function`

--- a/src/components/Admin/src/Composer.vue
+++ b/src/components/Admin/src/Composer.vue
@@ -23,9 +23,7 @@ export default {
     // One of authProvider or an authModule are strictly required
     const {
       props: {
-        authLayout,
         authProvider = () => {},
-        sidebar,
         options: _options = {}
       }
     } = context
@@ -33,7 +31,7 @@ export default {
     const options = Object.assign({}, {
       authModule: createAuthModule({ client: authProvider })
     }, _options)
-    const props = Object.assign({}, context.props, { sidebar, options })
+    const props = Object.assign({}, context.props, { options })
 
     return createElement(Admin, { props }, context.slots().default)
   }

--- a/src/components/Admin/src/Composer.vue
+++ b/src/components/Admin/src/Composer.vue
@@ -6,6 +6,9 @@ import createAuthModule from '@va-auth/store'
 export default {
   functional: true,
   props: {
+    authLayout: {
+      type: Object,
+    },
     authProvider: {
       type: Function
     },
@@ -20,6 +23,7 @@ export default {
     // One of authProvider or an authModule are strictly required
     const {
       props: {
+        authLayout,
         authProvider = () => {},
         sidebar,
         options: _options = {}


### PR DESCRIPTION
This PR provides:

+   bug fix on the admin `Composer` component. The `authLayout` prop was not declared.

Closes #149