### PR TITLE
Deprecate crud components as arrays

### DIFF
--- a/src/components/Resource/src/Resource.vue
+++ b/src/components/Resource/src/Resource.vue
@@ -1,5 +1,4 @@
 <script>
-import { List, Show, Create, Edit } from '@components/Actions'
 import { createCrudModule } from '@store/modules'
 import createRouteBindings from '@router/route.bindings'
 import defaults from './defaults'
@@ -13,13 +12,13 @@ export default {
       default: defaults().props.name,
     },
     list: {
-      type: [Array, Object],
+      type: Object,
       required: true,
       default: defaults().props.list,
     },
-    show: [Array, Object],
-    create: [Array, Object],
-    edit: [Array, Object],
+    show: Object,
+    create: Object,
+    edit: Object,
     resourceIdName: {
       type: String,
       default: defaults().props.resourceIdName,
@@ -79,10 +78,10 @@ export default {
         parseResponses: this.parseResponses,
       })
       // Adds binded components to routes
-      routes.push(bind.list({ wrapper: List }))
-      routes.push(bind.show({ wrapper: Show }))
-      routes.push(bind.create({ wrapper: Create }))
-      routes.push(bind.edit({ wrapper: Edit }))
+      routes.push(bind.list())
+      routes.push(bind.show())
+      routes.push(bind.create())
+      routes.push(bind.edit())
       // Adds the routes to the global router
       this.$router.addRoutes(routes)
     },

--- a/src/router/route.bindings.js
+++ b/src/router/route.bindings.js
@@ -40,116 +40,76 @@ export default ({
   const resourcePath = `/${resourceName}`
   const authUtils = createAuthUtils({ store })
   return {
-    list: ({ wrapper }) => {
+    list: () => {
       const name = `${resourceName}/list`
       const utils = listUtils({
         resourceName,
         store,
       })
-      if (list instanceof Array) {
-        // list should be an array based component
-        return {
-          path: resourcePath,
-          name,
-          component: wrapper,
-          props: {
-            resourceName,
-            fields: list,
-            hasShow,
-            hasCreate,
-            hasEdit,
-            resourceIdName,
-            // This could be refactored into a vue mixin, check #52 - @sgobotta
-            va: {
-              ...utils,
-            },
+      const { component, isPublic, permissions } = list
+      const routeHooks = createRouteHooks({
+        isPublic,
+        permissions,
+        store: authUtils,
+        userPermissionsField,
+      })
+      return {
+        path: resourcePath,
+        name,
+        component,
+        props: {
+          resourceName,
+          hasShow,
+          hasCreate,
+          hasEdit,
+          resourceIdName,
+          // This could be refactored into a vue mixin, check #52 - @sgobotta
+          va: {
+            ...utils,
           },
-        }
-      } else {
-        // list is an Object
-        const { component, isPublic, permissions } = list
-        const routeHooks = createRouteHooks({
+        },
+        meta: {
           isPublic,
           permissions,
-          store: authUtils,
-          userPermissionsField,
-        })
-        return {
-          path: resourcePath,
-          name,
-          component,
-          props: {
-            resourceName,
-            hasShow,
-            hasCreate,
-            hasEdit,
-            resourceIdName,
-            // This could be refactored into a vue mixin, check #52 - @sgobotta
-            va: {
-              ...utils,
-            },
-          },
-          meta: {
-            isPublic,
-            permissions,
-          },
-          ...routeHooks,
-        }
+        },
+        ...routeHooks,
       }
     },
 
-    show: ({ wrapper }) => {
+    show: () => {
       const name = `${resourceName}/show`
       const utils = showUtils({
         resourceName,
         router,
         store,
       })
-      if (show instanceof Array) {
-        // show should be a VA default component
-        return {
-          path: `${resourcePath}/show/:id`,
-          name,
-          component: wrapper,
-          props: {
-            resourceName,
-            fields: show,
-            // This could be refactored into a vue mixin, check #52 - @sgobotta
-            va: {
-              ...utils,
-            },
+      const { component, isPublic, permissions } = show
+      const routeHooks = createRouteHooks({
+        isPublic,
+        permissions,
+        store: authUtils,
+        userPermissionsField,
+      })
+      return {
+        path: `${resourcePath}/show/:id`,
+        name,
+        component,
+        props: {
+          resourceName,
+          // This could be refactored into a vue mixin, check #52 - @sgobotta
+          va: {
+            ...utils,
           },
-        }
-      } else {
-        // show is an Object
-        const { component, isPublic, permissions } = show
-        const routeHooks = createRouteHooks({
+        },
+        meta: {
           isPublic,
           permissions,
-          store: authUtils,
-          userPermissionsField,
-        })
-        return {
-          path: `${resourcePath}/show/:id`,
-          name,
-          component,
-          props: {
-            resourceName,
-            // This could be refactored into a vue mixin, check #52 - @sgobotta
-            va: {
-              ...utils,
-            },
-          },
-          meta: {
-            isPublic,
-            permissions,
-          },
-          ...routeHooks,
-        }
+        },
+        ...routeHooks,
       }
     },
 
-    create: ({ wrapper }) => {
+    create: () => {
       const name = `${resourceName}/create`
       const redirectView = redirection.views.create
       const utils = createUtils({
@@ -160,50 +120,33 @@ export default ({
         store,
         parseResponses,
       })
-      if (create instanceof Array) {
-        // create should be a VA default component
-        return {
-          path: `${resourcePath}/create`,
-          name,
-          component: wrapper,
-          props: {
-            resourceName,
-            fields: create,
-            va: {
-              ...utils,
-            },
+      const { component, isPublic, permissions } = create
+      const routeHooks = createRouteHooks({
+        isPublic,
+        permissions,
+        store: authUtils,
+        userPermissionsField,
+      })
+      return {
+        path: `${resourcePath}/create`,
+        name,
+        component,
+        props: {
+          // This could be refactored into a vue mixin, check #52 - @sgobotta
+          resourceName,
+          va: {
+            ...utils,
           },
-        }
-      } else {
-        // create is an Object
-        const { component, isPublic, permissions } = create
-        const routeHooks = createRouteHooks({
+        },
+        meta: {
           isPublic,
           permissions,
-          store: authUtils,
-          userPermissionsField,
-        })
-        return {
-          path: `${resourcePath}/create`,
-          name,
-          component,
-          props: {
-            // This could be refactored into a vue mixin, check #52 - @sgobotta
-            resourceName,
-            va: {
-              ...utils,
-            },
-          },
-          meta: {
-            isPublic,
-            permissions,
-          },
-          ...routeHooks,
-        }
+        },
+        ...routeHooks,
       }
     },
 
-    edit: ({ wrapper }) => {
+    edit: () => {
       const name = `${resourceName}/edit`
       const redirectView = redirection.views.edit
       const utils = editUtils({
@@ -214,46 +157,29 @@ export default ({
         store,
         parseResponses,
       })
-      if (edit instanceof Array) {
-        // edit should be a VA default component
-        return {
-          path: `${resourcePath}/edit/:id`,
-          name,
-          component: wrapper,
-          props: {
-            resourceName,
-            fields: edit,
-            va: {
-              ...utils,
-            },
+      const { component, isPublic, permissions } = edit
+      const routeHooks = createRouteHooks({
+        isPublic,
+        permissions,
+        store: authUtils,
+        userPermissionsField,
+      })
+      return {
+        path: `${resourcePath}/edit/:id`,
+        name,
+        component,
+        // This could be refactored into a vue mixin, check #52 - @sgobotta
+        props: {
+          resourceName,
+          va: {
+            ...utils,
           },
-        }
-      } else {
-        // edit is an Object
-        const { component, isPublic, permissions } = edit
-        const routeHooks = createRouteHooks({
+        },
+        meta: {
           isPublic,
           permissions,
-          store: authUtils,
-          userPermissionsField,
-        })
-        return {
-          path: `${resourcePath}/edit/:id`,
-          name,
-          component,
-          // This could be refactored into a vue mixin, check #52 - @sgobotta
-          props: {
-            resourceName,
-            va: {
-              ...utils,
-            },
-          },
-          meta: {
-            isPublic,
-            permissions,
-          },
-          ...routeHooks,
-        }
+        },
+        ...routeHooks,
       }
     },
   }


### PR DESCRIPTION
Hey, with this PR I'm deprecating the option to use crud view components as arrays as per https://github.com/Cambalab/vue-admin/issues/94

Is this acceptable?