### PR TITLE
210 the admin component ignores custom unauthorized layouts

### DIFF
--- a/demo/components/UnauthorizedView.vue
+++ b/demo/components/UnauthorizedView.vue
@@ -2,10 +2,7 @@
   <UnauthorizedLayout>
     <h2 slot="title">You do not have permissions for accessing this view</h2>
     <div slot="text">
-      <p>If you think you should be allowed to see this view, please contact the page administrator.</p>
-      <v-btn class="m-0" color="success" v-on:click="goBack">
-          BACK
-      </v-btn>
+      <p>If you think you should be allowed to see this view, please contact the page administrator</p>
     </div>
   </UnauthorizedLayout>
 </template>

--- a/src/components/Admin/src/Admin.vue
+++ b/src/components/Admin/src/Admin.vue
@@ -13,7 +13,7 @@ const {
     entitiesModule,
     requestsModule,
     resourceModule,
-    unauthorizedRoutes,
+    createUnauthorizedRoutes,
   },
 } = defaults()
 
@@ -62,6 +62,7 @@ export default {
     const { namespace } = AuthTypes
     const { authModule } = this.options
     const unauthenticatedRoutes = createUnauthenticatedRoutes(this.authLayout)
+    const unauthorizedRoutes = createUnauthorizedRoutes(this.unauthorized)
     const siteRoutes = createSiteRoutes({ homeLayout: this.homeLayout })
 
     this.$store.registerModule(namespace, authModule)

--- a/src/components/Admin/src/Composer.vue
+++ b/src/components/Admin/src/Composer.vue
@@ -22,6 +22,9 @@ export default {
     options: {
       type: Object,
     },
+    unauthorized: {
+      type: Object
+    }
   },
   render(createElement, context) {
     // One of authProvider or an authModule are strictly required

--- a/src/components/Admin/src/defaults.js
+++ b/src/components/Admin/src/defaults.js
@@ -22,7 +22,7 @@ export default () => {
   const homeLayout = HomeLayout
   const sidebar = DefaultSidebar
   const title = UI_CONTENT.MAIN_TOOLBAR_TITLE
-  const unauthorizedLayout = UnauthorizedLayout
+  const unauthorized = UnauthorizedLayout
 
   const createUnauthenticatedRoutes = anAuthLayout => [
     {
@@ -38,7 +38,7 @@ export default () => {
     {
       path: '/unauthorized',
       name: 'unauthorized',
-      component: anUnauthorizedLayout || unauthorizedLayout,
+      component: anUnauthorizedLayout || unauthorized,
     },
   ]}
 
@@ -58,7 +58,7 @@ export default () => {
       homeLayout,
       sidebar,
       title,
-      unauthorizedLayout,
+      unauthorized,
     },
     args: {
       alertsModule,

--- a/src/components/Admin/src/defaults.js
+++ b/src/components/Admin/src/defaults.js
@@ -22,30 +22,31 @@ export default () => {
   const homeLayout = HomeLayout
   const sidebar = DefaultSidebar
   const title = UI_CONTENT.MAIN_TOOLBAR_TITLE
-  const unauthorized = UnauthorizedLayout
+  const unauthorizedLayout = UnauthorizedLayout
 
-  const createUnauthenticatedRoutes = authLayout => [
+  const createUnauthenticatedRoutes = anAuthLayout => [
     {
       path: '/login',
       name: 'login',
-      component: authLayout || AuthLayout,
+      component: anAuthLayout || authLayout,
       props: {},
     },
   ]
 
-  const unauthorizedRoutes = [
+  const createUnauthorizedRoutes = anUnauthorizedLayout => {
+    return [
     {
       path: '/unauthorized',
       name: 'unauthorized',
-      component: UnauthorizedLayout,
+      component: anUnauthorizedLayout || unauthorizedLayout,
     },
-  ]
+  ]}
 
-  const createSiteRoutes = ({ homeLayout }) => [
+  const createSiteRoutes = ({ homeLayout: aHomeLayout }) => [
     {
       path: '/',
       name: 'home',
-      component: homeLayout || HomeLayout,
+      component: aHomeLayout || homeLayout,
       props: {},
     },
   ]
@@ -57,7 +58,7 @@ export default () => {
       homeLayout,
       sidebar,
       title,
-      unauthorized,
+      unauthorizedLayout,
     },
     args: {
       alertsModule,
@@ -66,7 +67,7 @@ export default () => {
       entitiesModule,
       requestsModule,
       resourceModule,
-      unauthorizedRoutes,
+      createUnauthorizedRoutes,
     },
   }
 }

--- a/src/components/Core/src/Core.vue
+++ b/src/components/Core/src/Core.vue
@@ -12,7 +12,6 @@ export default {
     const {
       props: { layout, title, sidebar, va },
     } = context
-
     return createElement(
       layout,
       {

--- a/tests/unit/factory/auth/index.js
+++ b/tests/unit/factory/auth/index.js
@@ -3,10 +3,24 @@
  *
  * @return {Object} An object with fake credentials
  */
-export default args => {
+export const createCredentials = args => {
   const _args = {
     username: 'dev@camba.coop',
     password: '123456',
+  }
+  return Object.assign({}, _args, args)
+}
+
+/**
+ * Creates fake credentials for an Auth component
+ *
+ * @return {Object} An object with fake credentials
+ */
+export const createUser = args => {
+  const _args = {
+    username: 'dev@camba.coop',
+    id: '234567',
+    permissions: ['admin']
   }
   return Object.assign({}, _args, args)
 }

--- a/tests/unit/factory/index.js
+++ b/tests/unit/factory/index.js
@@ -1,4 +1,4 @@
-import createCredentials from './auth'
+import { createCredentials, createUser } from './auth'
 import createStoreWith from './store'
 import { createAuthProvider } from './admin'
 
@@ -6,4 +6,5 @@ export default {
   createAuthProvider,
   createCredentials,
   createStoreWith,
+  createUser,
 }

--- a/tests/unit/specs/admin/admin.spec.js
+++ b/tests/unit/specs/admin/admin.spec.js
@@ -55,7 +55,6 @@ describe('Admin.vue', () => {
       authModule: createAuthModule({ client: authProvider }),
     }
     propsData = {
-      authProvider,
       options,
     }
     routerSpy = {
@@ -83,7 +82,8 @@ describe('Admin.vue', () => {
     expect(props.homeLayout).toMatchObject(adminFixture.props.homeLayout)
     expect(props.sidebar).toMatchObject(adminFixture.props.sidebar)
     expect(props.title).toMatch(adminFixture.props.title)
-    expect(props.unauthorized).toMatchObject(adminFixture.props.unauthorized)
+    expect(props.unauthorized)
+      .toMatchObject(adminFixture.props.unauthorized)
   })
 
   it('[Entities Module] - store should call registerModule on beforeCreate', () => {
@@ -157,14 +157,15 @@ describe('Admin.vue', () => {
     mountSubject()
 
     const {
-      props: { authLayout, homeLayout },
+      props: { authLayout, homeLayout, unauthorized },
       args: {
         createUnauthenticatedRoutes,
         createSiteRoutes,
-        unauthorizedRoutes,
+        createUnauthorizedRoutes,
       },
     } = adminFixture
     const unauthenticatedRoutes = createUnauthenticatedRoutes(authLayout)
+    const unauthorizedRoutes = createUnauthorizedRoutes(unauthorized)
     const siteRoutes = createSiteRoutes({ homeLayout })
     const args = [
       ...siteRoutes,

--- a/tests/unit/specs/admin/unauthenticated.spec.js
+++ b/tests/unit/specs/admin/unauthenticated.spec.js
@@ -2,6 +2,9 @@ import Vue from 'vue'
 import VueRouter from 'vue-router'
 import Vuex from 'vuex'
 import Unauthenticated from '@components/Admin/src/Unauthenticated'
+import Factory from '@unit/factory'
+import AuthTypes from '@va-auth/types'
+import authStore from '@va-auth/store'
 import { shallowMount } from '@vue/test-utils'
 import { Unauthenticated as unauthenticatedFixture } from '../../fixtures/admin'
 
@@ -17,6 +20,8 @@ describe('Unauthenticated.vue', () => {
   let mockedRouter
   let mockedStore
   let mocks
+  // spies
+  let storeSpy
   // props
   let propsData
 
@@ -32,10 +37,17 @@ describe('Unauthenticated.vue', () => {
   beforeEach(() => {
     const routes = [{}]
     mockedRouter = new VueRouter(routes)
-    mockedStore = new Vuex.Store({})
+    mockedStore = new Vuex.Store({
+      modules: {
+        auth: authStore({ client: () => new Promise(()=> {}) })
+      }
+    })
     mocks = { $store: mockedStore, $router: mockedRouter }
     propsData = {
       layout: unauthenticatedFixture.props.layout,
+    }
+    storeSpy = {
+      dispatch: jest.spyOn(mocks.$store, 'dispatch'),
     }
   })
 
@@ -61,5 +73,18 @@ describe('Unauthenticated.vue', () => {
     const authComponent = subjectWrapper.find(layout)
 
     expect(authComponent.exists()).toBe(true)
+  })
+
+  it('when the login method is called an [AUTH_LOGIN_REQUEST] action is dispatched', () => {
+    mountSubject()
+
+    const { namespace, AUTH_LOGIN_REQUEST } = AuthTypes
+    const action = `${namespace}/${AUTH_LOGIN_REQUEST}`
+    const { username, password } = Factory.createCredentials()
+
+    subjectWrapper.vm.login(username, password)
+
+    expect(storeSpy.dispatch).toHaveBeenCalledTimes(1)
+    expect(storeSpy.dispatch).toHaveBeenCalledWith(action, { username, password })
   })
 })


### PR DESCRIPTION
## Description

**Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.**

**This PR provides:**
-   Fix for the bug described in #210 

<!-- if it's a bug -->
Fixes #210 

## Type of change

**Please delete options that are not relevant.**

<!-- Edit below -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## How Has This Been Tested?

**Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce the cases. Please also list any relevant details for your test configuration**

<!-- Delete if no tests were ran -->

-   [x] Manual test

<!-- Provide instructions below -->

**Instructions:**

**1.** Use a custom layout in the authorized prop for the `Admin` component  
**2.** Visit an anauthorized page    

**Expected result:** The layout should be seen

## Checklist:

> The following options in **bold** are required for a PR approval. Please check the boxes only if necessary, it help us minimizing the reviewing process.

<!-- Edit below -->

-   [x] **I have performed a self-review of my own code**
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] **My changes generate no new warnings**
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] **New and existing unit tests pass locally with my changes**
